### PR TITLE
FIX: Pin to current stable Nibabies release, and more...

### DIFF
--- a/00_process_subjects.py
+++ b/00_process_subjects.py
@@ -1,4 +1,4 @@
-"""Sequentilly process multiple subjects with Nibabies."""
+"""Sequentially process multiple subjects with Nibabies."""
 
 import argparse
 import subprocess
@@ -16,20 +16,81 @@ import _3_delete_local_directories
 def parse_args():
     """Parse the command line arguments."""
     parser = argparse.ArgumentParser(description='Process multiple subjects with Nibabies.')
-    parser.add_argument("-p", "--project", choices=["BABIES", "ABC"], help='project name, such as BABIES')
-    parser.add_argument("-s", "--subjects", nargs="+", help="Space separated subject labels. such as '1103' '1027'")
-    parser.add_argument("-S", "--sessions", help="session label. such as 'newborn' 'sixmonth'")
-    parser.add_argument("-m", "--surface_recon_method", choices=["mcribs", "freesurfer"], help="surface reconstruction method, such as mcribs.")
-    parser.add_argument("--anat_only", action="store_true", help="only process anatomical data")
-    return parser.parse_args()
+    parser.add_argument(
+        "-p",
+        "--project",
+        choices=["BABIES", "ABC"],
+        required=True,
+        dest='project',
+        help='project name, such as BABIES'
+        )
+    parser.add_argument(
+        "-s",
+        "--subjects",
+        nargs="+",
+        required=True,
+        dest='subjects',
+        help="Space separated subject labels. such as '1103' '1027'"
+        )
+    parser.add_argument(
+        "-S",
+        "--session",
+        required=True,
+        choices=["newborn", "sixmonth"],
+        dest='session',
+        type=str,
+        help="session label. such as 'newborn' or 'sixmonth'")
+    parser.add_argument(
+        "-m",
+        "--surface-recon-method",
+        choices=["mcribs", "freesurfer"],
+        required=True,
+        dest='surface_recon_method',
+        help="surface reconstruction method, such as mcribs.")
+    parser.add_argument(
+        "--anat_only",
+        action="store_true",
+        dest="anat_only",
+        help="only process anatomical data")
+    parser.add_argument(
+        "--nibabies-version",
+        type=str,
+        dest="version",
+        default='latest',
+        help="version of Nibabies to use. Default is 'latest'."
+        )
+    parser.add_argument(
+        "--use_dev",
+        action="store_true",
+        dest="use_dev",
+        help="use the development version of Nibabies"
+    )
+    parser.add_argument(
+        "--nibabies_path",
+        type=str,
+        dest="nibabies_path",
+        default=None,
+        help="path to the local Nibabies repository. Only used if use_dev is used. If no path is provided, the default path is used."
+    )
+    args = parser.parse_args()
+    return vars(args)
 
-def process_one_subject(project, subject, session, surface_recon_method, anat_only=False):
+def process_one_subject(project, subject, session, surface_recon_method, anat_only=False, version="latest", use_dev=False, nibabies_path=None):
     """Process one subject. Use subprocess to run individual scripts."""
-    print(f" 👇 Processing started for subject {subject}👇 \n")
+    print(f" 👇 Processing started for subject {subject} {session}👇 \n")
     # Pull down the subject files from the server
     _0_pull_subject_files.main(project=project, subject=subject, session=session, anat_only=anat_only)
     # run nibabies
-    _1_run_nibabies.main(project=project, subject=subject, session=session, surface_recon_method=surface_recon_method, anat_only=anat_only)
+    _1_run_nibabies.main(
+        project=project,
+        subject=subject,
+        session=session,
+        surface_recon_method=surface_recon_method,
+        anat_only=anat_only,
+        version=version,
+        use_dev=use_dev,
+        nibabies_path=nibabies_path,
+        )
     # Push the subject Nibabies derivatives back to the server
     _2_push_derivatives.rsync_to_server(project=project, subject=subject, session=session, surface_recon_method=surface_recon_method)
     # Clean up local files
@@ -37,17 +98,35 @@ def process_one_subject(project, subject, session, surface_recon_method, anat_on
     print(f"✅ Processing completed for subject {subject}\n")
 
 
-def main():
+def main(**kwargs):
     """Process multiple subjects with Nibabies."""
-    args = parse_args()
-    project = args.project
-    subjects = args.subjects
-    session = args.sessions
-    surface_recon_method = args.surface_recon_method
-    anat_only = args.anat_only
-    for subject in subjects:
-       #sys.stdout = open(f'./sub-{subject}_ses-{session}_processing.log', 'w')
-        process_one_subject(project, subject, session, surface_recon_method, anat_only=anat_only)
+    project = kwargs["project"]
+    subjects = kwargs["subjects"]
+    session = kwargs["session"]
+    surface_recon_method = kwargs["surface_recon_method"]
+    anat_only = kwargs.get('anat_only', False)
+    version = kwargs["version"]
+    use_dev = kwargs.get("use_dev", False)
+    nibabies_path = kwargs.get("nibabies_path", None)
     
+    assert isinstance(anat_only, bool), "anat_only must be a boolean."
+    for subject in subjects:
+        # sys.stdout = open(f'./sub-{subject}_ses-{session}_processing.log', 'w')
+        print(f"\nProcessing")
+        process_one_subject(
+            project=project,
+            subject=subject,
+            session=session,
+            surface_recon_method=surface_recon_method,
+            anat_only=anat_only,
+            version=version,
+            use_dev=use_dev,
+            nibabies_path=nibabies_path,
+            )
+
+def run_main():
+    args = parse_args()
+    main(**args)
+
 if __name__ == "__main__":
-    main()
+    run_main()

--- a/_0_pull_subject_files.py
+++ b/_0_pull_subject_files.py
@@ -1,7 +1,6 @@
 import argparse
 
-import seababies as sea
-
+from utils.run import prepare_subject_files
 
 def main(**kwargs):
     # get the subject id, session id, and project name
@@ -9,7 +8,7 @@ def main(**kwargs):
     session = kwargs["session"]
     project = kwargs["project"]
     anat_only = kwargs.get("anat_only", False)
-    sea.run.prepare_subject_files(project, subject, session, anat_only=anat_only)
+    prepare_subject_files(project, subject, session, anat_only=anat_only)
 
 
 def parse_args():

--- a/_1_run_nibabies.py
+++ b/_1_run_nibabies.py
@@ -3,25 +3,93 @@ from pathlib import Path
 
 import seababies as sea
 
+from utils.docker import run_nibabies
+
+
 def main(**kwargs):
     # get the subject id, session id, and project name
     subject = kwargs["subject"]
     session = kwargs["session"]
     project = kwargs["project"]
     surface_recon_method = kwargs["surface_recon_method"]
+    version = kwargs["version"]
+    use_dev = kwargs.get("use_dev", False)
+    nibabies_path = kwargs.get("nibabies_path", None)
+    anat_only = kwargs.get("anat_only", False)
+
     session_dir = "six_month" if session == "sixmonth" and project == "BABIES" else session
     surface_recon_method = "infantfs" if surface_recon_method == "freesurfer" else surface_recon_method
-    anat_only = kwargs.get("anat_only", False)
-    sea.docker.run_nibabies(subject, session_dir, project, surface_recon_method, use_dev=True, anat_only=anat_only)
+    
+    run_nibabies(
+        subject=subject,
+        session=session_dir,
+        project=project,
+        surface_recon_method=surface_recon_method,
+        anat_only=anat_only,
+        version=version,
+        use_dev=use_dev,
+        nibabies_path=nibabies_path,
+        )
 
 def parse_args():
     # use argparse to get the subject id, session id, and project name
     parser = argparse.ArgumentParser(description='Run Nibabies.')
-    parser.add_argument('project', choices=["BABIES", "ABC"], help='project name, such as BABIES')
-    parser.add_argument('subject', type=str, help='subject label. such as 1103')
-    parser.add_argument('session', choices=["newborn", "sixmonth"], type=str, help='session label, such as newborn')
-    parser.add_argument("surface_recon_method", choices=["mcribs", "freesurfer"], help="surface reconstruction method, such as mcribs.")
-    parser.add_argument("--anat_only", action="store_true", help="only process anatomical data")
+    parser.add_argument(
+        '--project',
+        type=str,
+        choices=["BABIES", "ABC"],
+        dest='project',
+        required=True,
+        help='project name, such as BABIES'
+        )
+    parser.add_argument(
+        '--subject',
+        type=str,
+        required=True,
+        dest='subject',
+        help='subject label. such as 1103'
+        )
+    parser.add_argument(
+        '--session',
+        choices=["newborn", "sixmonth"],
+        required=True,
+        dest='session',
+        type=str,
+        help='session label, such as newborn'
+        )
+    parser.add_argument(
+        "--surface-recon-method",
+        choices=["mcribs", "freesurfer"],
+        required=True,
+        dest="surface_recon_method",
+        type=str,
+        help="surface reconstruction method, such as mcribs or freesurfer."
+        )
+    parser.add_argument(
+        "--anat-only",
+        dest="anat_only",
+        action="store_true",
+        help="only process anatomical data"
+        )
+    parser.add_argument(
+        "--nibabies_version",
+        type=str,
+        dest="version",
+        default="latest",
+        help="version of Nibabies to use. Default is latest. Can also be 'unstable' to use the current development version, or a specific version number, such as '24.0.0rc'.")
+    parser.add_argument(
+        "--use-dev",
+        action="store_true",
+        dest="use_dev",
+        help="use the development version of Nibabies repository."
+        )
+    parser.add_argument(
+        "--nibabies-path",
+        type=str,
+        dest="nibabies_path",
+        default=None,
+        help="path to the local Nibabies repository. Only used if use_dev is used. If no path is provided, the default path is used."
+        )
     args = parser.parse_args()
     return vars(args)
 

--- a/_3_delete_local_directories.py
+++ b/_3_delete_local_directories.py
@@ -1,8 +1,7 @@
 import argparse
 from pathlib import Path
 
-import seababies as sea
-
+from utils.utils import delete_directory
 
 def clean_up(subject, session, project, surface_recon_method):
     # get the subject id, session id, and project name
@@ -43,7 +42,7 @@ def clean_up(subject, session, project, surface_recon_method):
     for path in paths:   
         if path.exists() and path.is_dir():
             print(f"Removing {path}")
-            sea.utils.delete_directory(path)
+            delete_directory(path)
         else:
             print(f"{path} does not exist or is not a directory. Skipping.")
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+from . import config, docker, run, utils

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,0 +1,237 @@
+
+import json
+import logging
+import sys
+from pathlib import Path
+from warnings import warn
+
+import yaml
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+class Config(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__dict__ = self
+
+    def read(self, filename):
+        with open(filename, "r") as file:
+            data = json.load(file)
+            self.update(data)
+
+    def save(self, filename):
+        """Save the dictionary to a json file."""
+        filename = Path(filename)
+        # make posix path serializable
+        data = {k: str(v) for k, v in self.items()}
+        with open(filename, "w") as file:
+            json.dump(data, file, indent=4)
+
+
+class SubjectConfig(Config):
+    def __init__(self,
+                 project,
+                 subject_id,
+                 session,
+                 spatial_file=None,
+                 get_spatial_file=True,
+                 check_local_paths=False,
+                 anat_only=False,
+                 *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__dict__ = self
+        self["project"] = project
+        self["subject_id"] = subject_id
+        self["session"] = _get_session(session)
+        self["base_path"] = dict(server=Path("/Volumes/HumphreysLab/Daily_2") / project / "MRI",
+                                 local=Path("/Users/sealab/MRI_Processing") / project / "MRI")
+        self["server_paths"] = dict()
+        self["local_paths"] = dict()
+        self["anat_only"] = anat_only
+        self.populate_server_fpaths()
+        self.populate_local_fpaths(get_spatial_file=get_spatial_file, spatial_file=spatial_file, check=check_local_paths)
+    
+    
+    def __repr__(self):
+        """Return a string representation of the Config object."""
+        return (
+            f"SubjectConfig |\n"
+            f"Project: {self['project']}\n"
+            f"Subject: {self['subject_id']}\n"
+            f"Session: {self['session']}\n"
+            f"Server Path: {self['base_path']['server']}\n"
+            f"Local Path: {self['base_path']['local']}\n"
+        )
+
+    def populate_paths(self, base_path, path_dict, location, check=True, mode="raise"):
+        """Populate the dictionary with paths to the subject's files and directories."""
+        if location == "server":
+            this_dict = self["server_paths"]
+        elif location == "local":
+            this_dict = self["local_paths"]
+        else:
+            raise ValueError(f"location must be 'server' or 'local', not {location}")
+        for key, relative_path in path_dict.items():
+            full_path = base_path / relative_path
+            this_dict[key] = full_path
+        if check:
+            self.check_paths(server=location == "server", local=location == "local", mode=mode)
+    
+    def check_paths(self, server=True, local=False, mode="warn"):
+        """Check if the paths exist."""
+        paths = []
+        if server:
+            paths.append(self["server_paths"])
+        if local:
+            paths.append(self["local_paths"])
+        for path_dict in paths:
+            for name, path in path_dict.items():
+                try:
+                    self._check_path(path, name, mode)
+                except FileNotFoundError as e:
+                    # Don't raise an error if the precomputed or nibabies folder is missing on the server
+                    # because they won't exist until the first run of Nibabies
+                    if 'precomputed' in name or 'nibabies' in name:
+                        logger.debug(e)
+                    elif name.endswith("fname"):
+                        logger.debug(e)
+                    elif self["anat_only"] and (name.endswith("func") or name.endswith("funcpath") or name.endswith("fmappath")):
+                        logger.debug(e)
+                    else:
+                        raise e
+
+
+    def _check_path(self, path, name, mode="raise"):
+        """Check if a path exists."""
+        msg = f"The path for {name} does not exist: {path}"
+        path = Path(path)
+        if not path.exists():
+            if mode == "raise":
+                raise FileNotFoundError(msg)
+            elif mode == "warn":
+                warn(msg)
+        return path.exists()
+
+
+    
+    def create_path_dict(self, location="server"):
+        subject_id = self["subject_id"]
+        session = self["session"]
+        # SEALAB sometimes uses six_month instead of sixmonth. bids expects sixmonth
+        session_dir = "six_month" if session == "sixmonth" else session
+        base_path = self["base_path"][location]
+        paths = {
+            "project": base_path,
+            "bids": f"{session_dir}/bids",
+            "derivatives": f"{session_dir}/derivatives",
+            "nibabies": f"{session_dir}/derivatives/Nibabies",
+            "reconall": f"{session_dir}/derivatives/recon-all",
+            "precomputed": f"{session_dir}/derivatives/precomputed",
+            "sub_bpath": f"{session_dir}/bids/sub-{subject_id}/ses-{session}",
+            "sub_anatpath": f"{session_dir}/bids/sub-{subject_id}/ses-{session}/anat",
+            "sub_funcpath": f"{session_dir}/bids/sub-{subject_id}/ses-{session}/func",
+            "sub_fmappath": f"{session_dir}/bids/sub-{subject_id}/ses-{session}/fmap",
+            "sub_reconall": f"{session_dir}/derivatives/recon-all/sub-{subject_id}",
+            "sub_precomputed": f"{session_dir}/derivatives/precomputed/sub-{subject_id}/anat",
+            "sub_nibabies": f"{session_dir}/derivatives/Nibabies/sub-{subject_id}/ses-{session}"
+        }
+        return paths
+
+    def populate_server_fpaths(self):
+            """Populate the dictionary with paths to the subject's files and directories on the server."""
+            base_path = self["base_path"]["server"]
+            paths = self.create_path_dict()            
+            self.populate_paths(base_path, paths, "server")
+    
+    def populate_local_fpaths(self, get_spatial_file=True, spatial_file=None, check=False):
+        """Populate the dictionary with paths to the subject's files and directories on the local machine."""
+        base_path = self["base_path"]["local"]
+        paths = self.create_path_dict(location="local")
+        self.populate_paths(base_path, paths, "local", check=check)
+        if get_spatial_file:
+            self.get_spatial_file(spatial_file)
+    
+    def get_spatial_file(self, spatial_file=None, space="T2w"):
+        if space not in ["T1w", "T2w"]:
+            raise ValueError(f"space must be 'T1w' or 'T2w', not {space}")
+        subject_id = self["subject_id"]
+        session = self["session"]
+        if spatial_file is None:
+            pattern = f"sub-{subject_id}_ses-{session}_{space}.nii.gz"
+            print(f"Looking for:\n "
+                  f"    {pattern} \n" 
+                  f"    in {self['local_paths']['sub_anatpath']}")
+            spatial_file = list(self["local_paths"]["sub_anatpath"].glob(pattern))
+            if not spatial_file:
+                pattern = f"sub-{subject_id}_ses-{session}_run-??_{space}.nii.gz"
+                spatial_file = list(self["local_paths"]["sub_anatpath"].glob(pattern))
+            if not spatial_file:
+                files = list(self["local_paths"]["sub_anatpath"].glob("*.nii.gz"))
+                raise FileNotFoundError(f"No spatial file in {self['local_paths']['sub_anatpath']} matching {pattern}. Out of: \n {files}")
+            spatial_file = spatial_file[0]
+        else:
+            spatial_file = Path(spatial_file)
+            if not spatial_file.exists():
+                raise FileNotFoundError(f"{spatial_file} does not exist")
+        
+        self["spatial_file"] = spatial_file.resolve()
+        space_ = spatial_file.name.split("_")
+        if space_[2].startswith('run'):
+            self["space"] = space_[3][:3]
+        else:
+            self["space"] = space_[2][:3]
+        if self["space"] not in ["T1w", "T2w"]:
+            raise ValueError(f"Invalid space: {self['space']}")
+        
+        filenames = {
+            "precomputed_aseg_fname": f"sub-{subject_id}_ses-{session}_space-{self['space']}_desc-aseg_dseg.nii.gz",
+            "precomputed_mask_fname": f"sub-{subject_id}_ses-{session}_space-{self['space']}_desc-brain_mask.nii.gz",
+            "aseg_json_fname": f"sub-{subject_id}_ses-{session}_space-{self['space']}_desc-aseg_dseg.json",
+            "mask_json_fname": f"sub-{subject_id}_ses-{session}_space-{self['space']}_desc-brain_mask.json",
+            "aseg_json_fpath": self["local_paths"]["sub_precomputed"] / f"sub-{subject_id}_ses-{session}_space-{self['space']}_desc-aseg_dseg.json",
+            "mask_json_fpath": self["local_paths"]["sub_precomputed"] / f"sub-{subject_id}_ses-{session}_space-{self['space']}_desc-brain_mask.json"
+        }
+
+        self["local_paths"].update(filenames)
+
+    def read(self, file_name):
+        file_name = Path(file_name)
+        if not file_name.exists():
+            raise FileExistsError(
+                f"Configuration file {file_name.absolute()} " "does not exist"
+            )
+
+        with file_name.open("r") as file:
+            self.update(yaml.safe_load(file))
+            self.update({key: Path(value) if key not in ["project", "subject_id", "session"] else value for key, value in self.items()})
+    
+    def save(self, file_name):
+        """Save the current config object to disk as a YAML file.
+
+        Parameters
+        ----------
+        file_name : str | pathlib.Path
+            The file name to save the :class:`~pylossless.Config` object to.
+        """
+        file_name = Path(file_name)
+        config = {key: str(value) if isinstance(value, Path) else value for key, value in self.items()}
+        with file_name.open("w") as file:
+            yaml.dump(config, file, indent=4, sort_keys=True)
+
+    def print(self):
+        """Print the Config contents."""
+        yaml.dump(dict(self), sys.stdout, indent=4, sort_keys=True)
+
+
+def _get_session(session):
+    """SEALAB sometimes uses six_month instead of sixmonth. bids expects sixmonth"""
+    if session == "six_month":
+        return "sixmonth"
+    return session
+
+def read_subject_config(file_name):
+    """Read a subject configuration file and return a SubjectConfig object."""
+    config = SubjectConfig()
+    config.read(file_name)
+    return config

--- a/utils/docker.py
+++ b/utils/docker.py
@@ -1,0 +1,110 @@
+import subprocess
+from pathlib import Path
+
+from pprint import pprint as pp
+
+
+def run_docker_command(command):
+    """Run a docker command."""
+    print("\nRunning Docker command:\n"
+          f"    {command}"
+          )
+    print("\n")
+    subprocess.run(command, shell=True)
+
+def run_nibabies(
+        subject,
+        session,
+        project,
+        surface_recon_method,
+        root=None,
+        use_precomputed=True,
+        version='latest',
+        use_dev=False,
+        nibabies_path=None,
+        freesurfer_license=None,
+        anat_only=False,
+        verbose=True
+        ):
+    """Run Nibabies on a subject.
+    
+    Parameters
+    ----------
+    subject : str
+        The subject label. For example, "1027"
+    session : str
+        The session label. For example, "newborn" or "sixmonth"
+    project : str
+        The project label. For example, "ABC" or "BABIES"
+    surface_recon_method : str
+        The surface reconstruction method. For example, "mcribs", or "freesurfer".
+    root : str, optional
+        The root directory. Default is None, which uses "/Users/sealab/MRI_Processing".
+    use_precomputed : bool, optional
+        Whether to use precomputed derivatives. Default is True.
+    version : str, optional
+        The version of Nibabies to use. Default is "latest", which uses the current stable
+        version of Nibabies. Can also be "unstable" to use the current development version, or
+        a specific version number, such as "24.0.0rc".
+    use_dev : bool, optional
+        If true, this will bind a local Nibabies repository to the Docker container. Default is False.
+    nibabies_path : str, optional
+        The path to the local Nibabies repository. Default is None, which uses 
+        "/Users/sealab/devel/repos/nibabies/nibabies". Only used if use_dev is True.
+    freesurfer_license : str, optional
+        The path to the FreeSurfer licence file. Default is None, which uses
+        "/Applications/freesurfer/7.1.1/license.txt".
+    anat_only : bool, optional
+        If true, only run the anatomical processing. Default is False.
+    verbose : bool, optional
+        If true, run Nibabies in Verbose mode, to print more information. Default is True.
+    """
+    if root is None:
+        root = "/Users/sealab/MRI_Processing"
+    if freesurfer_license is None:
+        freesurfer_license = Path("./utils/assets/license.txt").resolve()
+        assert freesurfer_license.exists()
+
+    command = [
+        "docker", "run",
+        "-it",
+        "-v", f"{root}/{project}/MRI/{session}/bids:/data:ro",
+        "-v", f"{root}/{project}/MRI/{session}/derivatives/Nibabies:/out",
+        "-v", f"{root}/{project}/MRI/{session}/derivatives/work/nibabies_work:/scratch",
+        "-v", f"{freesurfer_license}:/opt/freesurfer/license.txt:ro",
+        ]
+    if use_precomputed:
+        command.extend([
+            "-v", f"{root}/{project}/MRI/{session}/derivatives/precomputed:/opt/derivatives/precomputed",
+            ])
+    if use_dev:
+        assert 1 == 0
+        if nibabies_path is None:
+            nibabies_path = "/Users/sealab/devel/repos/nibabies/nibabies"
+        command.extend([
+            "-v", f"{nibabies_path}:/opt/conda/envs/nibabies/lib/python3.10/site-packages/nibabies:ro",
+            ])
+    command.extend([
+        f"nipreps/nibabies:{version}",
+        "/data",
+        "/out",
+        "participant",
+        "--age-months", "1" if session == "newborn" else "6",
+        "--participant-label", subject,
+        "--derivatives", "/opt/derivatives/precomputed",
+        "-w", "/scratch",
+        "--surface-recon-method", surface_recon_method,
+        ])
+    if not anat_only:
+        command.extend([
+            "--cifti-output", "91k",
+            ])
+    else:
+        command.extend([
+            "--anat-only",
+            ])
+    if verbose:
+        command.extend([
+            "--verbose",
+            ])
+    run_docker_command(" ".join(command))

--- a/utils/run.py
+++ b/utils/run.py
@@ -1,0 +1,59 @@
+from .config import SubjectConfig
+from .utils import (
+    create_filter_file,
+    create_precomputed_files,
+    create_precomputed_jsons,
+    pull_subject_files,
+    rename_t1w_files,
+)
+
+
+def prepare_subject_files(
+        project,
+        subject_id,
+        session,
+        target_directory=None,
+        anat_only=False,
+        dry_run=False,
+        check_args=None,
+        verbose="INFO"):
+    """Prepare the files for a single subject to be run through Nibabies on a local machine like WHALE."""
+
+    if check_args is None:
+        check_args = {"local": True, "server": False, "mode": "error"}
+    config = SubjectConfig(project, subject_id, session, get_spatial_file=False, anat_only=anat_only)
+    project = config["project"]
+    subject_id = config["subject_id"]
+    session = config["session"]
+    p_root = "." if target_directory is None else target_directory
+    
+    pull_subject_files(
+        project,
+        subject_id,
+        session,
+        output_dir=p_root,
+        anat_only=anat_only,
+        dry_run=dry_run,
+        verbose=verbose,
+        )
+
+    config.get_spatial_file()
+    config.check_paths(local=True, server=False, mode="error")
+    rename_t1w_files(config["local_paths"]["sub_anatpath"])
+    
+    create_precomputed_files(
+        reconall_dir=config["local_paths"]["reconall"],
+        output_dir=config["local_paths"]["precomputed"],
+        subject=config["subject_id"],
+        session=config["session"],
+        space=config["space"],
+        overwrite=True,
+        )
+
+    create_precomputed_jsons(
+        precomputed_dir=config["local_paths"]["precomputed"],
+        spatial_reference_fname=config["spatial_file"],
+        subject=config["subject_id"],
+        session=config["session"],
+        space=config["space"]
+    )

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,0 +1,370 @@
+import shutil
+import subprocess
+from pathlib import Path
+from warnings import warn
+
+from .config import Config
+
+BABIES_SERVER = Path("/Volumes") / "HumphreysLab" / "Daily_2" / "BABIES" / "MRI"
+
+
+def rsync_to_server(project, subject, session, dry_run=False, verbose="INFO"):
+    """Use rsync to send files in Documents/MRI to the HumphreysLab server.
+    
+    Parameters
+    ----------
+    project : str
+        The project name. Must be either "BABIES" or "ABC".
+    subject : str
+        The subject id, for example "12001". Don't include the "sub-" prefix.
+    session : str
+        The session. Must be either "newborn" or "six_month", or "sixmonth", which is
+        an alias for "six_month".
+    dry_run : bool
+        If True, the function will not copy any files, but will print the rsync command.
+        Use this if you want to validate the behaviour of this function before
+        committing to the result. Default is False.
+    verbose : str
+        The verbosity level. Must be either "QUIET", "INFO", or "DEBUG". Default is "INFO".
+    """
+    if project not in ["BABIES", "ABC"]:
+        raise ValueError("project must be either 'BABIES' or 'ABC', but got: {project}")
+    if not subject.isnumeric():
+        raise ValueError("subject must be a number, but got: {subject}")
+    if session not in ["newborn", "six_month", "sixmonth"]:
+        raise ValueError("session must be either 'newborn' or 'six_month', but got: {session}")
+    if project == "ABC" and session == "six_month":
+        session = "sixmonth"
+    elif project == "BABIES" and session == "sixmonth":
+        session = "six_month"
+
+    input_dir = Path(".") / project / session
+    BABIES_SERVER = Path("/Volumes") / "HumphreysLab" / "Daily_2" / "BABIES" / "MRI"
+    ABC_SERVER = Path("/Volumes") / "HumphreysLab" / "Daily_2" / "ABC" / "MRI"
+    
+    
+    if project == "BABIES":
+        output_dir = BABIES_SERVER
+    elif project == "ABC":
+        output_dir = ABC_SERVER
+
+    # rsync the bids directory
+    bids_path = f"{str(input_dir)}/./bids/sub-{subject}"
+    assert bids_path.exists(), f"{bids_path} does not exist"
+    do_rsync(bids_path, output_dir, dry_run, verbose)
+
+    # rsync the derivatives/Nibabies/sourcedata/freesurfer directory
+    freesurfer_path = f"{str(input_dir)}/./derivatives/NiBabies/sourcedata/freesurfer/sub-{subject}"
+    assert freesurfer_path.exists(), f"{freesurfer_path} does not exist"
+    do_rsync(freesurfer_path, output_dir, dry_run, verbose)
+
+    # rsync the derivatives/Nibabies/sourcedata/subject directory
+    sourcedata_path = f"{str(input_dir)}/./derivatives/NiBabies/sourcedata/sub-{subject}"
+    assert sourcedata_path.exists(), f"{sourcedata_path} does not exist"
+    do_rsync(sourcedata_path, output_dir, dry_run, verbose)
+
+    # rsync the derivatives/sourcedata directory
+    sourcedata_path = f"{str(input_dir)}/./sourcedata/sub-{subject}"
+    assert sourcedata_path.exists(), f"{sourcedata_path} does not exist"
+    do_rsync(sourcedata_path, output_dir, dry_run, verbose)
+
+    # rsync the dicom2bids directory
+    dicom2bids_path = f"{str(input_dir)}/./tmp_dcm2bids/sub-{subject}_ses-{session}"
+    assert dicom2bids_path.exists(), f"{dicom2bids_path} does not exist"
+    do_rsync(dicom2bids_path, output_dir, dry_run, verbose)
+
+
+def pull_subject_files(
+    project, subject_id, session, output_dir, dry_run=False, anat_only=False, pull_dwi=False, verbose="INFO"):
+    """use rsync to pull the bids directory from 1 subject for a project like BABIES.
+
+    Parameters
+    ----------
+    project : str
+        Must be ``"BABIES"`` or ``"ABC"``, which will be converted to the
+        path for the project on the HumphreysLab server.
+    subject_id : str
+        The subject to copy. For example "12001".
+    session : str
+        The session to copy. Must be either "newborn" or "six_month".
+    output_dir : path-like
+        The output directory to copy to. Can either be a relative or absolute path.
+    dry_run : bool
+        If True, the function will not copy any files, but will print the rsync command.
+        Use this if you want to validate the behaviour of this function before
+        committing to the result. Default is False.
+    pull_dwi : bool
+        If True, the function will pull the bids dwi directory. Default is False.
+    """
+    BABIES = Path("/Volumes") / "HumphreysLab" / "Daily_2" / "BABIES" / "MRI"
+    ABC = Path("/Volumes") / "HumphreysLab" / "Daily_2" / "ABC" / "MRI"
+    if project == "BABIES":
+        input_dir = BABIES
+        session = "six_month" if session == "sixmonth" else session
+    elif project == "ABC":
+        input_dir = ABC
+
+    output_dir = Path(output_dir)
+
+    ##########################################################################
+    # CHECKS
+    ##########################################################################
+
+    if not input_dir.exists():
+        raise FileNotFoundError(f"{input_dir} does not exist")
+    if not output_dir.exists():
+        raise FileNotFoundError(f"{output_dir.resolve()} does not exist")
+    if not subject_id.isnumeric():
+        raise ValueError(
+            "subject_id must be a number, but got: {subject_id}\n" "Example: 12001 for sub-12001"
+        )
+    subject = f"sub-{subject_id}"
+
+    if session not in ["newborn", "six_month"]:
+        raise ValueError("session must be either 'newborn' 'sixmonth', or 'six_month'," " but got: {session}")
+    if not isinstance(anat_only, bool):
+        raise ValueError(f"anat_only must be a True or False, but got: {anat_only}")
+    if verbose not in ["QUIET", "INFO", "DEBUG"]:
+        raise ValueError(
+            "verbose must be either 'QUIET', 'INFO', or 'DEBUG'," " but got: {verbose}"
+        )
+
+    session_dir = input_dir / f"{session}"
+    assert session_dir.exists(), f"{session_dir} does not exist"
+    bids_dir = session_dir / "bids" / subject
+    assert bids_dir.exists(), f"{bids_dir} does not exist"
+    recon_dir = session_dir / "derivatives" / "recon-all" / subject
+    assert recon_dir.exists(), f"{recon_dir} does not exist"
+
+    ##########################################################################
+    # COPY
+    ##########################################################################
+
+    # we should use a logger instead of print
+    print(f"Copying {subject} directories from:\n {input_dir.resolve()} to:\n {output_dir.resolve()}")
+
+    # copy the entire subject directory
+    filter_dwi = not pull_dwi
+    filter_fpath = create_filter_file(output_dir, subject_id, session, anat_only=anat_only, filter_dwi=filter_dwi)
+    rsync_input = f"{str(input_dir.parent.parent)}/./{project}/MRI/{session}"
+    do_rsync(rsync_input, output_dir, filter_file=filter_fpath, dry_run=dry_run, verbose=verbose)
+
+
+
+def do_rsync(input_dir, output_dir, filter_file=None, dry_run=False, flags="-ahR", verbose="INFO"):
+    assert Path(input_dir).exists(), f"{input_dir} does not exist"
+    assert output_dir.exists(), f"{output_dir} does not exist"
+    flags = flags
+    if verbose == "INFO":
+        flags += "v"
+    elif verbose == "DEBUG":
+        flags += "vv"
+    if dry_run:
+        flags += "n"
+    
+    command = [
+            "rsync",
+            f"{flags}",
+            f"{input_dir}",
+            f"{output_dir}",
+            "--prune-empty-dirs",
+            "--progress",
+        ]
+    if filter_file is not None:
+        command += [f"--filter=merge {filter_file}"]
+    print(" ".join(command))
+    subprocess.run(command)
+    
+
+def delete_directory(path):
+    """Remove a path and all its contents."""
+    if not path.exists():
+        raise FileNotFoundError(f"{path} does not exist")
+    shutil.rmtree(path)
+
+
+def create_precomputed_jsons(precomputed_dir, spatial_reference_fname, subject, session, space="T2w"):
+    """Create json files for aseg and brain_mask.
+    
+    Parameters
+    ----------
+    precomputed_dir : path-like
+        The path to the precomputed directory. Do not include the subject or session.
+        For example, ``"/Users/sealab/MRI_Processing/BABIES/derivatives/precomputed"``.
+    spatial_reference_fname : path-like
+        The path to the spatial reference file, in the ``anat`` folder in the ``bids`` directory.
+        For example:
+        ``"/Users/sealab/MRI_Processing/BABIES/bids/subject/session/anat/sub-1401_ses-newborn_T1_coregistered2T2_ants_T1w.nii.gz"``.
+    """
+    aseg_json_fname = f"sub-{subject}_ses-{session}_space-{space}_desc-aseg_dseg.json"
+    mask_json_fname = f"sub-{subject}_ses-{session}_space-{space}_desc-brain_mask.json"
+    precomputed_dir = precomputed_dir / f"sub-{subject}"
+    aseg_json_fpath = precomputed_dir / "anat" / aseg_json_fname
+    mask_json_fpath = precomputed_dir / "anat" / mask_json_fname
+    bids_index = Path(spatial_reference_fname).parts.index('bids')
+    bpath = Path(*spatial_reference_fname.parts[:bids_index + 1])
+    spatial_reference_fname = spatial_reference_fname.relative_to(bpath)
+    # add the Spatial key to the jsons
+    aseg_json = Config()
+    aseg_json["SpatialReference"] = spatial_reference_fname
+    aseg_json.save(aseg_json_fpath)
+    mask_json = Config()
+    mask_json["SpatialReference"] = spatial_reference_fname
+    mask_json.save(mask_json_fpath)
+
+
+def create_precomputed_files(reconall_dir, output_dir, subject, session, space="T2w", overwrite=False):
+    """copy recon-all files to precomputed directory and rename them.
+    
+    Parameters
+    ----------
+    reconall_dir : path-like
+        The path to the local recon-all directory. Do not include the subject. For example,
+        ``"/users/selab/MRI_Processing/BABIES/derivatives/recon-all"``.
+        This can be a relative or absolute path.
+    output_dir : path-like
+        The path to the precomputed directory. Do not include the subject or session.
+        For example, ``"/Users/sealab/MRI_Processing/BABIES/derivatives/precomputed"``.
+    subject : str
+        The subject id, for example "12001".
+    session : str
+        The session. Must be either ``"newborn"`` or ``"six_month"``. Default is ``"newborn"``.
+    space : str
+        The space of the aseg and brain_mask files. Must be ``"T1w"`` or ``"T2w"``.
+        Default is "T1w".
+    overwrite : bool
+        If True, the function will overwrite the files in the precomputed directory (if a file
+        with the same name already exists). If False, the function will raise an error if a file
+        with the same name already exists. Default is False.
+    
+    Notes
+    -----
+    This function will look for a file named ``aseg.nii.gz`` and ``brain_mask.nii.gz`` in the
+    recon-all directory. It will copy these files to the precomputed directory and rename them
+    to the following format: ``{subject}_ses-{session}_space-{space}_desc-aseg_dseg.nii.gz``
+    and ``{subject}_ses-{session}_space-{space}_desc-brain_mask.nii.gz``.
+    """
+
+    # Checks
+    if not Path(reconall_dir).exists():
+        raise FileNotFoundError(f"{reconall_dir} does not exist")
+    if not Path(output_dir).exists():
+        raise FileNotFoundError(f"{output_dir} does not exist")
+    if space not in ["T1w", "T2w"]:
+        raise ValueError(f"space must be either 'T1w' or 'T2w', but got: {space}")
+    if not subject.isnumeric():
+        raise ValueError(f"subject must be a number, but got: {subject}")
+    if session not in ["newborn", "sixmonth"]:
+        raise ValueError(f"session must be either 'newborn' or 'six_month', but got: {session}")
+
+    output_dir = Path(output_dir).resolve()
+    recon_sub_dir = reconall_dir / f"sub-{subject}"
+    aseg_fpath = recon_sub_dir / "aseg.nii.gz"
+    assert aseg_fpath.exists(), f"{aseg_fpath} does not exist"
+    brain_mask_fpath = recon_sub_dir / "brain_mask.nii.gz"
+    assert brain_mask_fpath.exists(), f"{brain_mask_fpath} does not exist"
+    precomputed_aseg_fname = f"sub-{subject}_ses-{session}_space-{space}_desc-aseg_dseg.nii.gz"
+    precomputed_mask_fname = f"sub-{subject}_ses-{session}_space-{space}_desc-brain_mask.nii.gz"
+    if not (output_dir / f"sub-{subject}").exists():
+        (output_dir / f"sub-{subject}").mkdir()
+        (output_dir / f"sub-{subject}" / "anat").mkdir()
+    precomputed_aseg_fpath = output_dir / f"sub-{subject}" / "anat" / precomputed_aseg_fname
+    precomputed_mask_fpath = output_dir / f"sub-{subject}" / "anat" / precomputed_mask_fname
+    # copy aseg and mask to precomputed directory
+    if precomputed_aseg_fpath.exists():
+        if not overwrite:
+            raise FileExistsError(f"{precomputed_aseg_fpath} already exists. Set overwrite=True "
+                                   " to overwrite.")
+        else:
+            warn(f"{precomputed_aseg_fpath} already exists. Overwriting.")
+            precomputed_aseg_fpath.unlink()
+    
+    if precomputed_mask_fpath.exists():
+        if not overwrite:
+            raise FileExistsError(f"{precomputed_mask_fpath} already exists. Set overwrite=True "
+                                   " to overwrite.")
+        else:
+            warn(f"{precomputed_mask_fpath} already exists. Overwriting.")
+            precomputed_mask_fpath.unlink()
+    print(f"Copying {aseg_fpath} to {precomputed_aseg_fpath}\n")        
+    shutil.copy(aseg_fpath, precomputed_aseg_fpath)
+    print(f"Copying {brain_mask_fpath} to {precomputed_mask_fpath}\n")
+    shutil.copy(brain_mask_fpath, precomputed_mask_fpath)
+
+
+def create_filter_file(fpath, subject_id, session_dir, anat_only=False, filter_dwi=True):
+    """Create a filter file for a subject.
+    
+    Parameters
+    ----------
+    subject_id : str
+        The subject id, for example "12001".
+    session_dir : str
+        The session directory, for example "newborn" "six_month", or "sixmonth".
+    filter_dwi : bool
+        If True, the filter file will include the dwi directory. Default is True.
+    """
+    filter_file = Path(fpath)
+    filter_file = filter_file / f"{subject_id}_filter.txt"
+    session_bids = "sixmonth" if session_dir == "six_month" else session_dir
+    filter_func = "-" if anat_only else "+"
+    filter_dwi = "-" if filter_dwi else "+"
+    file_contents = [
+        f"+ {session_dir}/bids/",
+        f"+ {session_dir}/bids/sub-{subject_id}/",
+        f"+ {session_dir}/bids/sub-{subject_id}/ses-{session_bids}/",
+        f"- {session_dir}/bids/sub-{subject_id}/ses-{session_bids}/anat/*_raw.nii.gz",
+        f"+ {session_dir}/bids/sub-{subject_id}/ses-{session_bids}/anat/***",
+        f"{filter_func} {session_dir}/bids/sub-{subject_id}/ses-{session_bids}/func/***",
+        f"{filter_dwi} {session_dir}/bids/sub-{subject_id}/ses-{session_bids}/dwi/***",
+        f"{filter_dwi} {session_dir}/bids/sub-{subject_id}/ses-{session_bids}/fmap/sub-*_acq-dwi*",
+        f"{filter_func} {session_dir}/bids/sub-{subject_id}/ses-{session_bids}/fmap/***",
+        f"- {session_dir}/bids/sub-{subject_id}/ses-{session_bids}/**",
+        f"+ {session_dir}/derivatives/",
+        f"+ {session_dir}/derivatives/recon-all/",
+        f"+ {session_dir}/derivatives/recon-all/sub-{subject_id}/***",
+        f"- {session_dir}/bids/*",
+        f"- {session_dir}/derivatives/**",
+        f"- {session_dir}/bids_dwi/**",
+        f"- {session_dir}/bids_t2only/**",
+        f"- {session_dir}/code/**",
+        f"- {session_dir}/tmp_dcm2bids/**",
+        f"- {session_dir}/trash/**",
+        f"- {session_dir}/sourcedata/**",
+        f"- {session_dir}/data_share/**",
+        f"- {session_dir}/.DS_Store",
+        f"- {session_dir}/CABINET_Processing_IDs.xlsx",
+        f"- {session_dir}/dataset_description.json",
+        f"- {session_dir}/newborn_t1_t2_count.csv",
+        f"- {session_dir}/subs_only_one_t1_t2_TOTAL.xlsx"
+        ]
+
+    with filter_file.open("w") as file:
+        for line in file_contents:
+            file.write(line.strip() + "\n")
+    
+    print(f"Filter file saved to: {filter_file.resolve()}")
+    return filter_file
+
+
+def rename_t1w_files(anat_path):
+    """Rename T1w files to match the bids standard.
+    
+    Notes
+    -----
+    For example, ``sub-1011_ses-sixmonth_T1_coregistered2T2_ants_T1w.nii.gz`` will be renamed to
+    ``sub-1011_ses-sixmonth_T1w.nii.gz``.
+    """
+    anat_path = Path(anat_path)
+    if not anat_path.exists():
+        raise FileNotFoundError(f"{anat_path} does not exist")
+    t1w_files = list(anat_path.glob("sub-*_T1w.nii.gz"))
+    t1w_jsons = list(anat_path.glob("sub-*_T1w.json"))
+    new_names = []
+    for t1w in t1w_files + t1w_jsons:
+        new_name = t1w.name.replace("_T1_coregistered2T2_ants", "")
+        new_name = anat_path / new_name
+        t1w.rename(new_name)
+        print(f"Renamed {t1w} to {new_name}")
+        new_names.append(new_name)
+    return new_names


### PR DESCRIPTION

- By default, I pinned our local pipeline to use `nipreps/nibabies:'latest'`, which is a shorthand for the "current stable release". 
- I added a `utils` folder, that contains modules with helper functions for running our main scripts. These were moved from the other `seababies` package I started. Having these modules in this GitHub repository will make things simpler to debug, change etc.

- Added more CLI arguments so that one can control the nibabies version, etc from the command line. So for example we have `--nibabies-version` now.
- In the Command Line `00_process_subjects` I changed the ``--session`` argument to ``session`` (singular)
- I changed all underscores to hyphens in the command line argument names .... e.g. ``--surface_recon_method`` is now `--surface-recon-method`, and ``--anat_only`` is now ``--anat-only``.
- in `00_process_subjects` I gave the ``-surface-recon-method`` a default value of `freesurfer`, so that we don't _have to_ specify this every single time we process a subject. 
- I copied the freesurfer license file to this repository, that way, once we move our pipeline to ACCRE, we will still be able to easily access the file.


I am testing this branch out with the new NIbabies release candidate image, on subject `1366` `newborn`. Assuming things run well (no silly errors in our scripts), I will self-merge this branch.

Also,  Here is an example command for the updated API:


```bash

ipython -- 00_process_subjects.py --project "BABIES" --subjects "1366" --session "newborn" --surface-recon-method "mcribs" --anat-only
```
